### PR TITLE
Add required network to metamask

### DIFF
--- a/src/components/WalletLoader.jsx
+++ b/src/components/WalletLoader.jsx
@@ -33,7 +33,6 @@ export const WalletLoader = ({ onDisconnected, onConnected }) => {
     blockchainNetworkId,
     switchNetworkError,
     switchingNetwork,
-    switchNetwork,
     pendingChainId,
   } = wallet
 
@@ -107,7 +106,7 @@ export const WalletLoader = ({ onDisconnected, onConnected }) => {
       <LandingLayout {...layoutProps}>
         <WrongBlockchainNetwork
           blockchainNetworkName={blockchainNetworkName}
-          switchNetwork={switchNetwork}
+          connect={connect}
         />
       </LandingLayout>
     )

--- a/src/components/WrongBlockchainNetwork.jsx
+++ b/src/components/WrongBlockchainNetwork.jsx
@@ -1,11 +1,9 @@
 import React from 'react'
 import { Button, Divider, Message, Icon } from 'semantic-ui-react'
 import useTranslation from 'next-translate/useTranslation'
+import { handleNetworkSwitch } from '../lib/switchNetwork'
 
-export const WrongBlockchainNetwork = ({
-  blockchainNetworkName,
-  switchNetwork,
-}) => {
+export const WrongBlockchainNetwork = ({ blockchainNetworkName, connect }) => {
   const { t } = useTranslation('common')
 
   return (
@@ -29,7 +27,7 @@ export const WrongBlockchainNetwork = ({
 
         <Divider />
 
-        <Button primary onClick={() => switchNetwork()}>
+        <Button primary onClick={() => handleNetworkSwitch(connect)}>
           {t('components.wrong_blockchain_network.switch_network', {
             blockchainNetworkName: blockchainNetworkName,
           })}

--- a/src/lib/switchNetwork.js
+++ b/src/lib/switchNetwork.js
@@ -1,0 +1,39 @@
+import { blockchainNetwork } from './wagmi'
+import * as Sentry from '@sentry/nextjs'
+
+const getNetworkDetails = () => {
+  return {
+    chainId: `0x${blockchainNetwork.id.toString(16)}`,
+    chainName: blockchainNetwork.name,
+    nativeCurrency: {
+      name: blockchainNetwork.nativeCurrency.name,
+      symbol: blockchainNetwork.nativeCurrency.symbol,
+      decimals: blockchainNetwork.nativeCurrency.decimals,
+    },
+    rpcUrls: Object.values(blockchainNetwork.rpcUrls),
+    blockExplorerUrls: [blockchainNetwork.blockExplorers.default.url],
+  }
+}
+
+const switchNetwork = async (provider, networkDetails) => {
+  try {
+    await provider.request({
+      method: 'wallet_addEthereumChain',
+      params: [networkDetails],
+    })
+  } catch (error) {
+    Sentry.captureException(error)
+  }
+}
+
+export const handleNetworkSwitch = async (connect) => {
+  const provider = window.ethereum
+  const networkDetails = getNetworkDetails()
+  await switchNetwork(provider, networkDetails)
+
+  try {
+    await connect()
+  } catch (error) {
+    Sentry.captureException(error)
+  }
+}

--- a/src/lib/wagmi.js
+++ b/src/lib/wagmi.js
@@ -69,7 +69,7 @@ const networks = {
 }
 
 const { blockchainNetworkId } = getConfig().publicRuntimeConfig
-const blockchainNetwork = networks[blockchainNetworkId]
+export const blockchainNetwork = networks[blockchainNetworkId]
 if (!blockchainNetwork) {
   throw new Error(`Not supported blockchain network: ${blockchainNetworkId}!`)
 }


### PR DESCRIPTION
![Screenshot from 2023-05-29 15-58-44](https://github.com/optriment/optrispace-frontend-v2/assets/65503300/89497a4d-b77e-4db2-955c-988a71bba984)


- Upon clicking the "Switch Network" button, the system sends a request to add the required network to the user's wallet. The user needs to manually approve this request.

- After the user approves the network addition request, the system automatically switches the network to the newly added network in the user's wallet.

- Once the network switch is completed, the system establishes a connection between the user's wallet and the application, enabling seamless interaction.

- If the required network is already present in the user's wallet, the system directly switches to that network and connects the user's account to the application.